### PR TITLE
Fix profile forum notes listing and author edit/delete permissions

### DIFF
--- a/Frontend/src/assets/profile.css
+++ b/Frontend/src/assets/profile.css
@@ -502,6 +502,60 @@
   font-size: 0.84rem;
   font-weight: 800;
   white-space: nowrap;
+  cursor: pointer;
+}
+
+.note-link-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
+}
+
+.note-link-button.secondary {
+  background: #f4f1fb;
+  color: #625d79;
+}
+
+.note-link-button.danger {
+  background: #fff0f0;
+  color: #b42318;
+}
+
+.note-actions,
+.note-edit-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  justify-content: flex-end;
+}
+
+.note-edit-title,
+.note-edit-text {
+  width: 100%;
+  border: 1px solid rgba(160, 143, 220, 0.28);
+  border-radius: 18px;
+  background: #fff;
+  color: #21134b;
+  font: inherit;
+  outline: none;
+}
+
+.note-edit-title {
+  padding: 0.8rem 0.95rem;
+  font-weight: 800;
+}
+
+.note-edit-text {
+  min-height: 156px;
+  padding: 0.9rem 0.95rem;
+  line-height: 1.6;
+  resize: vertical;
+}
+
+.note-edit-title:focus,
+.note-edit-text:focus {
+  border-color: #8a68f8;
+  box-shadow: 0 0 0 3px rgba(138, 104, 248, 0.14);
 }
 
 .note-body {
@@ -695,6 +749,11 @@
 
   .note-card-header {
     flex-direction: column;
+  }
+
+  .note-actions,
+  .note-edit-actions {
+    justify-content: flex-start;
   }
 
   .interest-strip {

--- a/Frontend/src/views/Profile.vue
+++ b/Frontend/src/views/Profile.vue
@@ -66,18 +66,69 @@
             <div class="note-card-header">
               <div>
                 <p class="note-label">Forum note</p>
-                <h2>{{ note.eventTitle }}</h2>
+                <h2>{{ note.title || note.eventTitle }}</h2>
               </div>
-              <button
-                type="button"
-                class="note-link-button"
-                @click="openEvent(note.eventId)"
-              >
-                Open event
-              </button>
+              <div class="note-actions">
+                <button
+                  type="button"
+                  class="note-link-button"
+                  @click="openForumNote(note)"
+                >
+                  Open
+                </button>
+                <button
+                  type="button"
+                  class="note-link-button"
+                  @click="startEditingNote(note)"
+                >
+                  Edit
+                </button>
+                <button
+                  type="button"
+                  class="note-link-button danger"
+                  :disabled="deletingNoteId === note.id"
+                  @click="deleteForumNote(note)"
+                >
+                  {{ deletingNoteId === note.id ? 'Deleting...' : 'Delete' }}
+                </button>
+              </div>
             </div>
-            <p class="note-body">{{ note.text }}</p>
+            <template v-if="editingNoteId === note.id">
+              <input
+                v-model="editNoteTitle"
+                class="note-edit-title"
+                type="text"
+                maxlength="120"
+                placeholder="Title"
+              />
+              <textarea
+                v-model="editNoteText"
+                class="note-edit-text"
+                rows="6"
+                placeholder="Share your note"
+              ></textarea>
+              <div class="note-edit-actions">
+                <button
+                  type="button"
+                  class="note-link-button"
+                  :disabled="savingNoteId === note.id || !editNoteText.trim()"
+                  @click="saveForumNote(note)"
+                >
+                  {{ savingNoteId === note.id ? 'Saving...' : 'Save' }}
+                </button>
+                <button
+                  type="button"
+                  class="note-link-button secondary"
+                  :disabled="savingNoteId === note.id"
+                  @click="cancelEditingNote"
+                >
+                  Cancel
+                </button>
+              </div>
+            </template>
+            <p v-else class="note-body">{{ note.text }}</p>
             <div class="note-meta">
+              <span>{{ note.eventTitle }}</span>
               <span>{{ note.eventSchedule }}</span>
               <span v-if="note.eventLocation">{{ note.eventLocation }}</span>
               <span>{{ formatPostTimestamp(note.createdAt) }}</span>
@@ -211,13 +262,18 @@ import { computed, onMounted, onUnmounted, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import {
   collection,
-  collectionGroup,
+  deleteDoc,
+  deleteField,
+  doc as firestoreDoc,
   documentId,
   getDocs,
   getFirestore,
   query,
+  serverTimestamp,
+  updateDoc,
   where,
 } from 'firebase/firestore';
+import { auth } from '../firebase/config';
 import { useUserStore } from '../stores/user';
 import { formatEventCardSchedule, formatEventSchedule, RecurrenceType, type Event as FullEvent } from '../types/event';
 
@@ -243,8 +299,10 @@ interface ForumNoteCard {
   eventTitle: string;
   eventLocation: string;
   eventSchedule: string;
+  title: string;
   text: string;
   createdAt: unknown;
+  userId: string;
 }
 
 const router = useRouter();
@@ -259,6 +317,11 @@ const currentSection = ref<SectionKey>('saved');
 const savedEvents = ref<ProfileEventCard[]>([]);
 const forumNotes = ref<ForumNoteCard[]>([]);
 const userEvents = ref<ProfileEventCard[]>([]);
+const editingNoteId = ref<string | null>(null);
+const editNoteTitle = ref('');
+const editNoteText = ref('');
+const savingNoteId = ref<string | null>(null);
+const deletingNoteId = ref<string | null>(null);
 
 const savedUpcomingEvents = computed(() => savedEvents.value.filter((event) => !isPassedEvent(event)));
 const passedSavedEvents = computed(() => savedEvents.value.filter((event) => isPassedEvent(event)));
@@ -322,6 +385,105 @@ function openEvent(eventId: string) {
       returnTo: route.fullPath,
     },
   });
+}
+
+function openForumNote(note: ForumNoteCard) {
+  router.push(`/forum/posts/${note.eventId}/${note.id}`);
+}
+
+function startEditingNote(note: ForumNoteCard) {
+  editingNoteId.value = note.id;
+  editNoteTitle.value = note.title;
+  editNoteText.value = note.text === '(Empty note)' ? '' : note.text;
+}
+
+function cancelEditingNote() {
+  editingNoteId.value = null;
+  editNoteTitle.value = '';
+  editNoteText.value = '';
+}
+
+function getForumNoteRef(note: ForumNoteCard) {
+  return firestoreDoc(db, 'events', note.eventId, 'forumPosts', note.id);
+}
+
+function getFirebaseErrorMessage(error: unknown) {
+  const firebaseError = error as { code?: string; message?: string };
+  return firebaseError.code
+    ? `${firebaseError.code}: ${firebaseError.message ?? 'No details'}`
+    : firebaseError.message ?? 'Unknown error';
+}
+
+function canModifyForumNote(note: ForumNoteCard) {
+  const currentUserId = auth.currentUser?.uid;
+
+  if (currentUserId && currentUserId === note.userId) return true;
+
+  console.warn('Forum note ownership mismatch:', {
+    currentUserId,
+    noteUserId: note.userId,
+    eventId: note.eventId,
+    noteId: note.id,
+  });
+  alert('You can only edit or delete forum notes posted by your current login account.');
+  return false;
+}
+
+async function saveForumNote(note: ForumNoteCard) {
+  const nextText = editNoteText.value.trim();
+  if (!nextText || savingNoteId.value) return;
+  if (!canModifyForumNote(note)) return;
+
+  savingNoteId.value = note.id;
+
+  try {
+    const nextTitle = editNoteTitle.value.trim();
+    const updates: Record<string, unknown> = {
+      content: nextText,
+      text: nextText,
+      updatedAt: serverTimestamp(),
+    };
+
+    updates.title = nextTitle || nextText.slice(0, 90);
+    updates.bodyHtml = deleteField();
+
+    await updateDoc(getForumNoteRef(note), updates);
+
+    forumNotes.value = forumNotes.value.map((item) => (
+      item.id === note.id
+        ? {
+            ...item,
+            title: typeof updates.title === 'string' ? updates.title : item.title,
+            text: nextText,
+          }
+        : item
+    ));
+    cancelEditingNote();
+  } catch (error) {
+    console.error('Failed to update forum note:', error);
+    alert(`Failed to update this forum note. ${getFirebaseErrorMessage(error)}`);
+  } finally {
+    savingNoteId.value = null;
+  }
+}
+
+async function deleteForumNote(note: ForumNoteCard) {
+  if (deletingNoteId.value) return;
+  if (!canModifyForumNote(note)) return;
+  if (!confirm('Delete this forum note?')) return;
+
+  deletingNoteId.value = note.id;
+
+  try {
+    await deleteDoc(getForumNoteRef(note));
+    forumNotes.value = forumNotes.value.filter((item) => item.id !== note.id);
+    if (editingNoteId.value === note.id) cancelEditingNote();
+  } catch (error) {
+    console.error('Failed to delete forum note:', error);
+    alert(`Failed to delete this forum note. ${getFirebaseErrorMessage(error)}`);
+  } finally {
+    deletingNoteId.value = null;
+  }
 }
 
 function isEventSaved(eventId: string) {
@@ -576,39 +738,44 @@ async function fetchUserEvents(userId: string) {
 }
 
 async function fetchForumNotes(userId: string) {
-  const snapshot = await getDocs(
-    query(collectionGroup(db, 'posts'), where('userId', '==', userId)),
+  const eventMap = new Map<string, Record<string, any>>();
+  const allEventsSnapshot = await getDocs(collection(db, 'events'));
+
+  allEventsSnapshot.docs.forEach((doc) => {
+    eventMap.set(doc.id, doc.data() as Record<string, any>);
+  });
+
+  const noteQueryResults = await Promise.allSettled(
+    allEventsSnapshot.docs.map((eventDoc) =>
+      getDocs(query(collection(db, 'events', eventDoc.id, 'forumPosts'), where('userId', '==', userId))),
+    ),
   );
 
-  if (snapshot.empty) {
+  const noteDocs = noteQueryResults.flatMap((result) => {
+    if (result.status === 'fulfilled') return result.value.docs;
+
+    console.warn('Failed to load forum notes for an event:', result.reason);
+    return [];
+  });
+
+  if (noteDocs.length === 0) {
     forumNotes.value = [];
     return;
   }
 
-  const eventIds = Array.from(new Set(
-    snapshot.docs
-      .map((doc) => doc.ref.parent.parent?.id)
-      .filter((id): id is string => Boolean(id)),
-  ));
-
-  const eventMap = new Map<string, Record<string, any>>();
-  for (let index = 0; index < eventIds.length; index += 10) {
-    const chunk = eventIds.slice(index, index + 10);
-    const eventSnapshot = await getDocs(
-      query(collection(db, 'events'), where(documentId(), 'in', chunk)),
-    );
-
-    eventSnapshot.docs.forEach((doc) => {
-      eventMap.set(doc.id, doc.data() as Record<string, any>);
-    });
-  }
-
-  forumNotes.value = snapshot.docs
+  forumNotes.value = noteDocs
     .map((doc) => {
-      const post = doc.data() as { text?: string; createdAt?: unknown };
+      const post = doc.data() as {
+        title?: string;
+        content?: string;
+        text?: string;
+        createdAt?: unknown;
+        userId?: string;
+      };
       const eventId = doc.ref.parent.parent?.id ?? '';
       const eventData = eventMap.get(eventId);
       const eventForSchedule = eventData ? ({ ...eventData, id: eventId } as FullEvent) : null;
+      const text = (post.content || post.text || '').trim();
 
       return {
         id: doc.id,
@@ -616,8 +783,10 @@ async function fetchForumNotes(userId: string) {
         eventTitle: eventData?.title || 'Deleted Event',
         eventLocation: eventData?.location || '',
         eventSchedule: eventForSchedule ? formatEventSchedule(eventForSchedule) : 'Schedule TBD',
-        text: post.text?.trim() || '(Empty note)',
+        title: post.title?.trim() || '',
+        text: text || '(Empty note)',
         createdAt: post.createdAt,
+        userId: post.userId ?? '',
       };
     })
     .sort((left, right) => getTimestampMs(right.createdAt) - getTimestampMs(left.createdAt));


### PR DESCRIPTION
Fixes “Your Forum Notes” in Profile so it only shows forum notes, not comments. Adds open, edit, and delete actions for the user’s own notes, with Firestore rules deployed to allow note authors to update/delete their forumPosts.